### PR TITLE
Fix concurrent iteration bug in remove_all_matching()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ========
 
+0.3.3
+
+- Fix but in `remove_all_matching()` which could cause entries to be skipped
+
 0.3.1
 
 - Add repr and str for each class

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include AUTHORS.rst
 include CONTRIBUTING.rst
 include HISTORY.rst
 include LICENSE
-include README.rst
+include README.md
 
 recursive-include tests *
 recursive-exclude * __pycache__

--- a/python_hosts/hosts.py
+++ b/python_hosts/hosts.py
@@ -247,15 +247,15 @@ class Hosts(object):
         :return: None
         """
         if self.entries:
-            to_remove = []
             if address and name:
-                to_remove = (x for x in self.entries if x.address == address and name in x.names)
+                to_remove = lambda x: x.address == address and name in x.names
             elif address:
-                to_remove = (x for x in self.entries if x.address == address)
+                to_remove = lambda x: x.address == address
             elif name:
-                to_remove = (x for x in self.entries if x.names and name in x.names)
-            for item_to_remove in to_remove:
-                self.entries.remove(item_to_remove)
+                to_remove = lambda x: x.names and name in x.names
+            else:
+                return
+            self.entries = [x for x in self.entries if not to_remove(x)]
 
     def import_url(self, url=None):
         """

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -56,7 +56,7 @@ def test_exception_raised_when_unable_to_write_hosts(tmpdir):
     hosts_file = tmpdir.mkdir("etc").join("hosts")
     hosts_file.write("127.0.0.1\tlocalhost\n")
     hosts = Hosts(path=hosts_file.strpath)
-    os.chmod(hosts_file.strpath, 0444)
+    os.chmod(hosts_file.strpath, 0o444)
     new_entry = HostsEntry(entry_type='ipv4', address='123.123.123.123', names=['test.example.com'])
     hosts.add(entries=[new_entry])
     with pytest.raises(exception.UnableToWriteHosts):

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -468,3 +468,13 @@ def test_file_import_fails_when_not_readable(tmpdir):
     hosts_entries = Hosts(path=hosts_file.strpath)
     result = hosts_entries.import_file('/invalid_file')
     assert result.get('result') == 'failed'
+
+
+def test_remove_all_matching_multiple(tmpdir):
+    hosts_file = tmpdir.mkdir("etc").join("hosts")
+    hosts_file.write("1.2.3.4\tfoo-1 foo\n"
+                     "2.3.4.5\tfoo-2 foo\n")
+    hosts = Hosts(path=hosts_file.strpath)
+    hosts.remove_all_matching(name="foo")
+    hosts.write()
+    assert hosts_file.read() == ""

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py332,py334
+envlist = py26,py27,py32,py34
 [testenv]
 deps=
     pytest


### PR DESCRIPTION
The confusing behavior seen in #1 is partially due to a bug in `remove_all_matching()`.  Because it iterates over the list of entries while it is removing them, it can end up skipping entries.  This PR fixes that, and also makes the removal behavior O(n).

I also fixed some trivial things that prevented Tox from running cleanly for me.