### PR TITLE
Remove unused win_inet_pton dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     author_email='jon@lessknown.co.uk',
     url='https://github.com/jonhadfield/python-hosts',
     download_url='https://github.com/jonhadfield/python-hosts/tarball/{0}'.format(version),
-    install_requires=['win_inet_pton==1.0.1'],
     description='A hosts file manager library written in python',
     long_description='A hosts file manager library written in python',
     packages=['python_hosts'],


### PR DESCRIPTION
It is no longer used since https://github.com/jonhadfield/python-hosts/commit/3b88d3a42000256584cbf58b3c9aad69cc83842c#diff-bd746762c3f5a5c3066a37b19ec8240c.