### PR TITLE
remove last remnants of win_inet_pton

### DIFF
--- a/python_hosts/utils.py
+++ b/python_hosts/utils.py
@@ -4,7 +4,6 @@ This module contains utility functions used by the Hosts and HostsEntry methods
 """
 import os
 import re
-import win_inet_pton
 
 import socket
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-win_inet_pton

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     description='A hosts file manager library written in python',
     long_description='A hosts file manager library written in python',
     packages=['python_hosts'],
-    install_requires=['win_inet_pton'],
     platforms='any',
     license='MIT',
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,6 @@ commands =
 
 deps =
     enum-compat
-    win_inet_pton
     PyYAML>=3.11
     pytest>=3.0.3
     pytest-cov>=2.4.0
@@ -39,7 +38,6 @@ norecursedirs = .tox .git
 commands = py.test --cov-report term-missing --cov python-hosts
 deps =
     enum-compat
-    win_inet_pton
     PyYAML>=3.11
     pytest>=3.0.3
     pytest-cov>=2.4.0


### PR DESCRIPTION
I gather from PR #19 that win_inet_pton was removed. However, there still is an import statement for it in python_hosts/utils.py. Removing that line got me over Python complaining about the missing module and made it possible to use the code in Linux. There are further references to it in requirements.txt, setup.py and (2 lines) tox.ini. These didn’t stop me as I didn’t install for now but they will probably be a problem in other scenarios. This PR removes them all.