### PR TITLE
fix str repr

### DIFF
--- a/python_hosts/hosts.py
+++ b/python_hosts/hosts.py
@@ -161,7 +161,7 @@ class Hosts(object):
             self.populate_entries()
 
     def __repr__(self):
-        return 'Hosts(path=\'{0}\', entries={1!r})'.format(
+        return 'Hosts(path={0!r}, entries={1!r})'.format(
             self.path, self.entries
         )
 

--- a/python_hosts/hosts.py
+++ b/python_hosts/hosts.py
@@ -188,7 +188,8 @@ class Hosts(object):
         if not platform:
             platform = sys.platform
         if platform.startswith('win'):
-            return r"c:\windows\system32\drivers\etc\hosts"
+            result = r"c:\windows\system32\drivers\etc\hosts"
+            return result
         else:
             return '/etc/hosts'
 

--- a/python_hosts/hosts.py
+++ b/python_hosts/hosts.py
@@ -188,8 +188,7 @@ class Hosts(object):
         if not platform:
             platform = sys.platform
         if platform.startswith('win'):
-            result = r"c:\windows\system32\drivers\etc\hosts"
-            return result
+            return r"c:\windows\system32\drivers\etc\hosts"
         else:
             return '/etc/hosts'
 

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -243,14 +243,14 @@ def test_hosts_repr(tmpdir):
     hosts_file = tmpdir.mkdir("etc").join("hosts")
     hosts_file.write("6.6.6.6\texample.com\n")
     hosts = Hosts(path=hosts_file.strpath)
-    assert (repr(hosts)) == "Hosts(path='{0}', " \
+    assert (repr(hosts)) == "Hosts(path={0!r}, " \
                             "entries=[HostsEntry(entry_type='ipv4', " \
                             "address='6.6.6.6', " \
                             "names=['example.com'], " \
                             "comment=None)])".format(hosts_file.strpath)
     hosts_file.write("6.6.6.6\texample.com # devilish ip...\n")
     hosts = Hosts(path=hosts_file.strpath)
-    assert (repr(hosts)) == "Hosts(path='{0}', " \
+    assert (repr(hosts)) == "Hosts(path={0!r}, " \
                             "entries=[HostsEntry(entry_type='ipv4', " \
                             "address='6.6.6.6', " \
                             "names=['example.com'], " \
@@ -627,7 +627,7 @@ def test_existing_comments_and_blanks_are_preserved(tmpdir):
 
 def test_hostsentry_initialisation_failure_with_invalid_type():
     """
-    Test initialiser returns an exception if the type is invalid 
+    Test initialiser returns an exception if the type is invalid
     """
     with pytest.raises(Exception):
         HostsEntry()
@@ -754,7 +754,7 @@ def test_file_import_fails_when_not_readable(tmpdir):
 
 
 def test_remove_all_matching_multiple(tmpdir):
-    """ 
+    """
     Test removal of multiple entries with a common alias
     """
     hosts_file = tmpdir.mkdir("etc").join("hosts")


### PR DESCRIPTION
mentioned in https://github.com/jonhadfield/python-hosts/pull/45

> Sorry, I didn't see the image as it doesn't show on the GitHub app on iOS.
> 
> When Hosts had a path that didn't use string literals, and so included double backslashes, the repr (in the formatting) would show with single backslashes. As the repr needs to be something you can execute to reproduce the object, having single backslashes means it couldn't be evaluated. I thought about having the repr return `Host(path=r'{0!r}'... ` but it looked messy in contrast. I also looked at Path but that isn't in 2.7 and I'm trying to retain that compatibilty.


literal string and non-literal string have same repr, `assert repr(r'ss\ss') == repr('ss\\ss')`

Current repr of path in `Hosts` is still not valid...


```py
from python_hosts import Hosts

print(repr(Hosts()))
```

```
Hosts(path='c:\windows\system32\drivers\etc\hosts', entries=[...])
```

It's expected to be `Hosts(path='c:\\windows\\system32\\drivers\\etc\\hosts', entries=[...]`, repr of single backslash should be double backslashes.

https://github.com/jonhadfield/python-hosts/blob/04bf6cddf9fce40cf317c0d3773b9467ad37fb06/python_hosts/hosts.py#L163-L166

So current manually quoted is not valid, it should be `return 'Hosts(path={0!r}, entries={1!r})'.format(self.path, self.entries)`